### PR TITLE
https://github.com/DesignLiquido/delegua-node/issues/20

### DIFF
--- a/fontes/importador/importador-javascript.ts
+++ b/fontes/importador/importador-javascript.ts
@@ -17,6 +17,11 @@ export class ImportadorJavaScript implements ImportadorInterface<(Statement | Di
     lexador: LexadorJavaScript;
     avaliadorSintatico: AvaliadorSintaticoJavaScript;
 
+    constructor() {
+        this.lexador = new LexadorJavaScript();
+        this.avaliadorSintatico = new AvaliadorSintaticoJavaScript();
+    }
+
     importar(caminhoRelativoArquivo: string, importacaoInicial: boolean): RetornoImportador<(Statement | Directive | ModuleDeclaration), (Statement | Directive | ModuleDeclaration)> {
         const nomeArquivo = caminho.basename(caminhoRelativoArquivo);
         let caminhoAbsolutoArquivo = caminho.resolve(this.diretorioBase, caminhoRelativoArquivo);
@@ -27,10 +32,6 @@ export class ImportadorJavaScript implements ImportadorInterface<(Statement | Di
         const hashArquivo = cyrb53(caminhoAbsolutoArquivo.toLowerCase());
         const dadosDoArquivo: Buffer = sistemaArquivos.readFileSync(caminhoAbsolutoArquivo);
         const conteudoDoArquivo: string[] = dadosDoArquivo.toString().replace(sistemaOperacional.EOL, '\n').split('\n');
-
-        for (let linha = 0; linha < conteudoDoArquivo.length; linha++) {
-            conteudoDoArquivo[linha] += '\0';
-        }
 
         const retornoLexador = this.lexador.mapear(conteudoDoArquivo, hashArquivo);
         const retornoAvaliadorSintatico = this.avaliadorSintatico.analisar(retornoLexador, hashArquivo);
@@ -44,5 +45,4 @@ export class ImportadorJavaScript implements ImportadorInterface<(Statement | Di
             retornoAvaliadorSintatico,
         } as RetornoImportador<(Statement | Directive | ModuleDeclaration), (Statement | Directive | ModuleDeclaration)>;
     }
-    
 }

--- a/fontes/nucleo-traducao.ts
+++ b/fontes/nucleo-traducao.ts
@@ -17,7 +17,7 @@ export class NucleoTraducao
     extends NucleoComum
 {
     importador: ImportadorInterface<any, any>;
-    tradutor: TradutorInterface;
+    tradutor: TradutorInterface<any>;
     funcaoDeRetorno: Function;
     funcaoDeRetornoMesmaLinha: Function;
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "testes:servidor-depuracao": "ts-node ./fontes/depuracao/servidor-depuracao.ts"
     },
     "dependencies": {
-        "@designliquido/delegua": "0.24.5",
+        "@designliquido/delegua": "0.24.6",
         "chalk": "4.1.2",
         "commander": "^9.4.1",
         "json-colorizer": "^2.2.2",

--- a/testes/nucleo-traducao.test.ts
+++ b/testes/nucleo-traducao.test.ts
@@ -1,0 +1,13 @@
+import { NucleoTraducao } from "../fontes/nucleo-traducao";
+
+describe('Núcleo de tradução', () => {
+    it('`traduzirArquivo`, javascript-para-delegua', () => {
+        let retornoSaida: string = '';
+        const funcaoDeRetorno = (saida: string) => retornoSaida += saida;
+        const nucleoTraducao = new NucleoTraducao(funcaoDeRetorno);
+        nucleoTraducao.iniciarTradutor('javascript-para-delegua');
+        nucleoTraducao.traduzirArquivo('./exemplos/tradutores/javascript-para-delegua.js', false);
+
+        expect(retornoSaida).toContain("escreva('JavaScript para Delégua!!!')");
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,10 +337,10 @@
   resolved "https://registry.yarnpkg.com/@designliquido/delegua-tempo/-/delegua-tempo-0.0.1.tgz#964834d127354857cda1c388f5de9327735b6747"
   integrity sha512-/O1/eXlTXPTWSZGZ862i6uHHKCW0cmP6KnOV29zK4d4hgn03QjcNDeFKVC9L9vz3OJ6pPY0d/S8ANJkgBnnoaQ==
 
-"@designliquido/delegua@0.24.5":
-  version "0.24.5"
-  resolved "https://registry.yarnpkg.com/@designliquido/delegua/-/delegua-0.24.5.tgz#fc1aded417182c38336e9f5687c8150ce8f3ffbf"
-  integrity sha512-7QjUb7PyptVFPLMKs5igUwwxTMfvqscm67giZNM2JEFF11ax29KAIJ+bwlCcySepX7XewJun33yBLn2//zDj/g==
+"@designliquido/delegua@0.24.6":
+  version "0.24.6"
+  resolved "https://registry.yarnpkg.com/@designliquido/delegua/-/delegua-0.24.6.tgz#33c692c27fb2bb6f100403dfc0c82fc861a23ae3"
+  integrity sha512-2PAQdU5Ypd22CnNkBxulD1rZ4o9fXe4q4fN+ftB69QEDfTx5N3zYVZbSWKCwKTrIrHt6bkafmhhrsuh4CxVtwA==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
     browser-process-hrtime "^1.0.0"


### PR DESCRIPTION
- Atualização do núcleo da linguagem para a versão 0.24.6;
- Adição de testes unitários para o núcleo de tradução;
- Adequações no importador de JavaScript para evitar erros com o Esprima.