### PR TITLE
Usando novos pacotes de dialetos, que deixarão de fazer parte do núcleo de Delégua + ajustes.

### DIFF
--- a/execucao.ts
+++ b/execucao.ts
@@ -59,7 +59,7 @@ const principal = async () => {
     }
 
     if (opcoes.codigo) {
-        await delegua.executarCodigoComoArgumento(
+        return await delegua.executarCodigoComoArgumento(
             opcoes.codigo || codigoOuNomeArquivo,
             opcoes.dialeto,
             Boolean(opcoes.performance)

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -40,7 +40,7 @@ export class Delegua implements DeleguaInterface {
 
             return JSON.parse(sistemaArquivos.readFileSync(manifesto, { encoding: 'utf8' })).version || '0.26';
         } catch (error: any) {
-            return '0.24 (desenvolvimento)';
+            return '0.32 (desenvolvimento)';
         }
     }
 

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -51,7 +51,7 @@ export class Delegua implements DeleguaInterface {
     ): Promise<void> {
         const nucleoExecucao = new NucleoExecucao(this.versao(), this.funcaoDeRetorno, this.funcaoDeRetornoMesmaLinha);
         nucleoExecucao.configurarDialeto(dialeto, performance);
-        await nucleoExecucao.executarCodigoComoArgumento(codigo);
+        return await nucleoExecucao.executarCodigoComoArgumento(codigo);
     }
 
     async executarCodigoPorArquivo(
@@ -61,13 +61,13 @@ export class Delegua implements DeleguaInterface {
     ): Promise<any> {
         const nucleoExecucao = new NucleoExecucao(this.versao(), this.funcaoDeRetorno, this.funcaoDeRetornoMesmaLinha);
         nucleoExecucao.configurarDialeto(dialeto, performance);
-        await nucleoExecucao.carregarEExecutarArquivo(caminhoRelativoArquivo);
+        return await nucleoExecucao.carregarEExecutarArquivo(caminhoRelativoArquivo);
     }
 
     async iniciarLair(dialeto: string = 'delegua'): Promise<void> { 
         const nucleoExecucao = new NucleoExecucao(this.versao(), this.funcaoDeRetorno, this.funcaoDeRetornoMesmaLinha);
         nucleoExecucao.configurarDialeto(dialeto, false);
-        await nucleoExecucao.iniciarLairDelegua();
+        return await nucleoExecucao.iniciarLairDelegua();
     }
 
     traduzirArquivo(

--- a/fontes/nucleo-execucao.ts
+++ b/fontes/nucleo-execucao.ts
@@ -26,8 +26,6 @@ import {
   AvaliadorSintaticoPitugues,
   AvaliadorSintaticoMapler,
   AvaliadorSintaticoPortugolIpt,
-  AvaliadorSintaticoPortugolStudio,
-  AvaliadorSintaticoVisuAlg,
   AvaliadorSintaticoPotigol,
 } from "@designliquido/delegua/fontes/avaliador-sintatico/dialetos";
 import {
@@ -35,9 +33,6 @@ import {
   InterpretadorEguaClassico,
   InterpretadorMapler,
   InterpretadorPortugolIpt,
-  InterpretadorPortugolStudioComDepuracao,
-  InterpretadorPortugolStudio,
-  InterpretadorVisuAlg,
   InterpretadorPotigol,
 } from "@designliquido/delegua/fontes/interpretador/dialetos";
 import { InterpretadorPotigolComDepuracao } from '@designliquido/delegua/fontes/interpretador/dialetos/potigol/interpretador-potigol-com-depuracao';
@@ -48,10 +43,17 @@ import {
   LexadorPitugues,
   LexadorMapler,
   LexadorPortugolIpt,
-  LexadorPortugolStudio,
-  LexadorVisuAlg,
   LexadorPotigol,
 } from "@designliquido/delegua/fontes/lexador/dialetos";
+
+import { LexadorPortugolStudio } from "@designliquido/portugol-studio/fontes/lexador";
+import { AvaliadorSintaticoPortugolStudio } from '@designliquido/portugol-studio/fontes/avaliador-sintatico';
+import { InterpretadorPortugolStudio, InterpretadorPortugolStudioComDepuracao } from '@designliquido/portugol-studio/fontes/interpretador';
+
+import { LexadorVisuAlg } from '@designliquido/visualg/fontes/lexador';
+import { AvaliadorSintaticoVisuAlg } from '@designliquido/visualg/fontes/avaliador-sintatico';
+import { InterpretadorVisuAlg } from '@designliquido/visualg/fontes/interpretador';
+
 import { Interpretador } from "./interpretador";
 import { InterpretadorMaplerComDepuracaoImportacao } from "./interpretador/dialetos/interpretador-mapler-com-depuracao-importacao";
 import { InterpretadorVisuAlgComDepuracaoImportacao } from "./interpretador/dialetos/interpretador-visualg-com-depuracao-importacao";

--- a/fontes/nucleo-execucao.ts
+++ b/fontes/nucleo-execucao.ts
@@ -46,9 +46,9 @@ import {
   LexadorPotigol,
 } from "@designliquido/delegua/fontes/lexador/dialetos";
 
-import { LexadorPortugolStudio } from "@designliquido/portugol-studio/fontes/lexador";
-import { AvaliadorSintaticoPortugolStudio } from '@designliquido/portugol-studio/fontes/avaliador-sintatico';
-import { InterpretadorPortugolStudio, InterpretadorPortugolStudioComDepuracao } from '@designliquido/portugol-studio/fontes/interpretador';
+import { LexadorPortugolStudio } from "@designliquido/portugol-studio/lexador";
+import { AvaliadorSintaticoPortugolStudio } from '@designliquido/portugol-studio/avaliador-sintatico';
+import { InterpretadorPortugolStudio, InterpretadorPortugolStudioComDepuracao } from '@designliquido/portugol-studio/interpretador';
 
 import { LexadorVisuAlg } from '@designliquido/visualg/fontes/lexador';
 import { AvaliadorSintaticoVisuAlg } from '@designliquido/visualg/fontes/avaliador-sintatico';

--- a/fontes/nucleo-execucao.ts
+++ b/fontes/nucleo-execucao.ts
@@ -381,7 +381,7 @@ export class NucleoExecucao
     // Se a interface de entrada e saída ainda não está definida, definimos agora.
     // A interface pode ser definida por um teste unitário antes da execução
     // aqui, por exemplo.
-    let interfaceLeitura: any;
+    let interfaceLeitura: readline.Interface | any;
     if (!this.interpretador.interfaceEntradaSaida) {
       interfaceLeitura = readline.createInterface({
         input: process.stdin,
@@ -410,19 +410,19 @@ export class NucleoExecucao
       errosExecucao = erros;
     }
 
-    if (interfaceLeitura && interfaceLeitura.hasOwnProperty("close")) {
+    if (interfaceLeitura && (interfaceLeitura instanceof readline.Interface || interfaceLeitura.hasOwnProperty("close"))) {
       interfaceLeitura.close();
     }
 
-    if (errosExecucao.length > 0) process.exit(70); // Código com exceções não tratadas
-    process.exit(0);
+    if (errosExecucao.length > 0) process.exitCode = 70; // Código com exceções não tratadas
+    return;
   }
 
   /**
    * LAIR (Leia-Avalie-Imprima-Repita) é o modo em que Delégua executa em modo console,
    * ou seja, esperando como entrada linhas de código fornecidas pelo usuário.
    */
-  iniciarLairDelegua(): void {
+  async iniciarLairDelegua(): Promise<void> {
     const lexadorJson = new LexadorJson();
     const formatadorJson = new FormatadorJson();
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,5 +7,6 @@ export default async (): Promise<Config.InitialOptions> => {
         preset: 'ts-jest',
         testEnvironment: 'node',
         coverageReporters: ['json-summary', 'lcov', 'text', 'text-summary'],
+        detectOpenHandles: true
     };
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@designliquido/delegua": "0.32.2",
         "@designliquido/portugol-studio": "^0.0.0",
-        "@designliquido/visualg": "^0.0.0",
+        "@designliquido/visualg": "^0.0.1",
         "chalk": "4.1.2",
         "commander": "^9.4.1",
         "json-colorizer": "^2.2.2"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
         "@designliquido/visualg": "^0.0.0",
         "chalk": "4.1.2",
         "commander": "^9.4.1",
-        "json-colorizer": "^2.2.2",
-        "lodash.clonedeep": "^4.5.0"
+        "json-colorizer": "^2.2.2"
     },
     "devDependencies": {
         "@designliquido/delegua-estatistica": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.32.2",
     "description": "Linguagem Delégua com capacidades para ecossistema Node.js.",
     "scripts": {
-        "empacotar": "rimraf ./dist && tsc && copyfiles -V ./bin/delegua ./bin/delegua.cmd ./dist && copyfiles -V ./package.json ./dist/bin && copyfiles -V ./README.md ./dist && copyfiles -V ./LICENSE ./dist",
+        "empacotar": "yarn rimraf ./dist && tsc && yarn copyfiles -V ./bin/delegua ./bin/delegua.cmd ./dist && yarn copyfiles -V ./package.json ./dist/bin && yarn copyfiles -V ./README.md ./dist && yarn copyfiles -V ./LICENSE ./dist",
         "testes-unitarios": "jest --coverage",
         "testes:egua": "./bin/delegua-ts exemplos/dialetos/egua-classico/testes.egua",
         "testes:delegua:bhaskara": "./bin/delegua-ts exemplos/dialetos/egua-classico/bhaskara.egua",
@@ -13,6 +13,8 @@
     },
     "dependencies": {
         "@designliquido/delegua": "0.32.2",
+        "@designliquido/portugol-studio": "^0.0.0",
+        "@designliquido/visualg": "^0.0.0",
         "chalk": "4.1.2",
         "commander": "^9.4.1",
         "json-colorizer": "^2.2.2",

--- a/testes/nucleo-execucao.test.ts
+++ b/testes/nucleo-execucao.test.ts
@@ -23,6 +23,13 @@ describe('Núcleo de execução', () => {
         const funcaoDeRetorno = (saida: string) => retornoSaida += saida;
         const nucleoExecucao = new NucleoExecucao('0.1', funcaoDeRetorno);
         nucleoExecucao.configurarDialeto();
+
+        const realProcess = process;
+        const exitMock = jest.fn();
+
+        // Mock de `process.exit`.
+        // Se não for feito, o teste falha.
+        global.process = { ...realProcess, exit: exitMock as any };
         
         // Aqui vamos simular a resposta para duas variáveis de `leia()`.
         const respostas = [
@@ -35,6 +42,8 @@ describe('Núcleo de execução', () => {
         };
         await nucleoExecucao.carregarEExecutarArquivo('./exemplos/condicionais/escolha-com-enquanto.delegua');
 
+        expect(exitMock).toHaveBeenCalledWith(0);
         expect(retornoSaida.length).toBeGreaterThan(0);
+        global.process = realProcess;
     });
 });

--- a/testes/nucleo-execucao.test.ts
+++ b/testes/nucleo-execucao.test.ts
@@ -24,12 +24,14 @@ describe('Núcleo de execução', () => {
         const nucleoExecucao = new NucleoExecucao('0.1', funcaoDeRetorno);
         nucleoExecucao.configurarDialeto();
 
-        const processReal = process;
-        const exitMock = jest.fn();
+        // const processReal = process;
+        // const exitMock = jest.fn();
 
         // Mock de `process.exit`.
         // Se não for feito, o teste falha.
-        global.process = { ...processReal, exit: exitMock as any };
+        // @ts-ignore: `process.exit()` retorna `never`.
+        const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+        // global.process = { ...processReal, exit: exitMock as any };
         
         // Aqui vamos simular a resposta para duas variáveis de `leia()`.
         const respostas = [
@@ -42,8 +44,8 @@ describe('Núcleo de execução', () => {
         };
         await nucleoExecucao.carregarEExecutarArquivo('./exemplos/condicionais/escolha-com-enquanto.delegua');
 
-        expect(exitMock).toHaveBeenCalledWith(0);
+        expect(mockExit).toHaveBeenCalledWith(0);
         expect(retornoSaida.length).toBeGreaterThan(0);
-        global.process = processReal;
+        // global.process = processReal;
     });
 });

--- a/testes/nucleo-execucao.test.ts
+++ b/testes/nucleo-execucao.test.ts
@@ -24,12 +24,12 @@ describe('Núcleo de execução', () => {
         const nucleoExecucao = new NucleoExecucao('0.1', funcaoDeRetorno);
         nucleoExecucao.configurarDialeto();
 
-        const realProcess = process;
+        const processReal = process;
         const exitMock = jest.fn();
 
         // Mock de `process.exit`.
         // Se não for feito, o teste falha.
-        global.process = { ...realProcess, exit: exitMock as any };
+        global.process = { ...processReal, exit: exitMock as any };
         
         // Aqui vamos simular a resposta para duas variáveis de `leia()`.
         const respostas = [
@@ -44,6 +44,6 @@ describe('Núcleo de execução', () => {
 
         expect(exitMock).toHaveBeenCalledWith(0);
         expect(retornoSaida.length).toBeGreaterThan(0);
-        global.process = realProcess;
+        global.process = processReal;
     });
 });

--- a/testes/nucleo-execucao.test.ts
+++ b/testes/nucleo-execucao.test.ts
@@ -23,15 +23,6 @@ describe('Núcleo de execução', () => {
         const funcaoDeRetorno = (saida: string) => retornoSaida += saida;
         const nucleoExecucao = new NucleoExecucao('0.1', funcaoDeRetorno);
         nucleoExecucao.configurarDialeto();
-
-        // const processReal = process;
-        // const exitMock = jest.fn();
-
-        // Mock de `process.exit`.
-        // Se não for feito, o teste falha.
-        // @ts-ignore: `process.exit()` retorna `never`.
-        const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
-        // global.process = { ...processReal, exit: exitMock as any };
         
         // Aqui vamos simular a resposta para duas variáveis de `leia()`.
         const respostas = [
@@ -44,8 +35,6 @@ describe('Núcleo de execução', () => {
         };
         await nucleoExecucao.carregarEExecutarArquivo('./exemplos/condicionais/escolha-com-enquanto.delegua');
 
-        expect(mockExit).toHaveBeenCalledWith(0);
         expect(retornoSaida.length).toBeGreaterThan(0);
-        // global.process = processReal;
     });
 });

--- a/testes/nucleo-traducao.test.ts
+++ b/testes/nucleo-traducao.test.ts
@@ -6,17 +6,9 @@ describe('Núcleo de tradução', () => {
         const funcaoDeRetorno = (saida: string) => retornoSaida += saida;
         const nucleoTraducao = new NucleoTraducao(funcaoDeRetorno);
 
-        const processReal = process;
-        const exitMock = jest.fn();
-
-        // Mock de `process.exit`.
-        // Se não for feito, o teste falha.
-        global.process = { ...processReal, exit: exitMock as any };
-
         nucleoTraducao.iniciarTradutor('javascript-para-delegua');
         nucleoTraducao.traduzirArquivo('./exemplos/tradutores/javascript-para-delegua.js', false);
 
         expect(retornoSaida).toContain("escreva('JavaScript para Delégua!!!')");
-        global.process = processReal;
     });
 });

--- a/testes/nucleo-traducao.test.ts
+++ b/testes/nucleo-traducao.test.ts
@@ -5,9 +5,18 @@ describe('Núcleo de tradução', () => {
         let retornoSaida: string = '';
         const funcaoDeRetorno = (saida: string) => retornoSaida += saida;
         const nucleoTraducao = new NucleoTraducao(funcaoDeRetorno);
+
+        const processReal = process;
+        const exitMock = jest.fn();
+
+        // Mock de `process.exit`.
+        // Se não for feito, o teste falha.
+        global.process = { ...processReal, exit: exitMock as any };
+
         nucleoTraducao.iniciarTradutor('javascript-para-delegua');
         nucleoTraducao.traduzirArquivo('./exemplos/tradutores/javascript-para-delegua.js', false);
 
         expect(retornoSaida).toContain("escreva('JavaScript para Delégua!!!')");
+        global.process = processReal;
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,13 +354,13 @@
   dependencies:
     "@designliquido/delegua" "^0.32.2"
 
-"@designliquido/visualg@^0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@designliquido/visualg/-/visualg-0.0.0.tgz#26b7331848e79c32b44a4bf2a9175d768efaaea8"
-  integrity sha512-paRPLUKz1EsuSBf0ipt9K/+kUbWgMf2GvPkFV2FsYT0OwOTi+77ivGGMP8sCs+AKEv9r3WM0QemOLyFk5FL/kg==
+"@designliquido/visualg@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@designliquido/visualg/-/visualg-0.0.1.tgz#650e24ad914aeae0465a72b6a9eea6cb1c2b6619"
+  integrity sha512-SV2O9g51iN6VM/dmYkml23BUYbKEwT9eIVja/koGTrKcG3tRfL5vMaiWSdghSLuBmBgtmOPJ6Tenj3y1nc66Rg==
   dependencies:
     "@designliquido/delegua" "^0.32.2"
-    lodash.clonedeep "^4.5.0"
+    lodash "^4.17.21"
 
 "@iarna/toml@2.2.5":
   version "2.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,7 +337,7 @@
   resolved "https://registry.yarnpkg.com/@designliquido/delegua-tempo/-/delegua-tempo-0.0.1.tgz#964834d127354857cda1c388f5de9327735b6747"
   integrity sha512-/O1/eXlTXPTWSZGZ862i6uHHKCW0cmP6KnOV29zK4d4hgn03QjcNDeFKVC9L9vz3OJ6pPY0d/S8ANJkgBnnoaQ==
 
-"@designliquido/delegua@0.32.2":
+"@designliquido/delegua@0.32.2", "@designliquido/delegua@^0.32.2":
   version "0.32.2"
   resolved "https://registry.yarnpkg.com/@designliquido/delegua/-/delegua-0.32.2.tgz#97dbffc39b17fd280ada32e141da7547a80edbfa"
   integrity sha512-2iEW78j+SMt57uvDeC366RuDcOWkmU2wQ1lMhbGvF8JnbrjK4vijXk/aEHtsr03M0wGnjUERoGx4l/jCWmedFA==
@@ -345,6 +345,21 @@
     antlr4ts "^0.5.0-alpha.4"
     browser-process-hrtime "^1.0.0"
     esprima "^4.0.1"
+    lodash.clonedeep "^4.5.0"
+
+"@designliquido/portugol-studio@^0.0.0":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@designliquido/portugol-studio/-/portugol-studio-0.0.0.tgz#cf40e6f0c2837b32e35e84332211b5c56073ccc7"
+  integrity sha512-al4IR4HZRw5q9Ujsf6B6I+3Sy3G2jEhYCeli90iZKfxq7meNBmwqXiUvWdrX1RpM6scwWDO1UDVHTlASYyan9g==
+  dependencies:
+    "@designliquido/delegua" "^0.32.2"
+
+"@designliquido/visualg@^0.0.0":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@designliquido/visualg/-/visualg-0.0.0.tgz#26b7331848e79c32b44a4bf2a9175d768efaaea8"
+  integrity sha512-paRPLUKz1EsuSBf0ipt9K/+kUbWgMf2GvPkFV2FsYT0OwOTi+77ivGGMP8sCs+AKEv9r3WM0QemOLyFk5FL/kg==
+  dependencies:
+    "@designliquido/delegua" "^0.32.2"
     lodash.clonedeep "^4.5.0"
 
 "@iarna/toml@2.2.5":


### PR DESCRIPTION
Depende de https://github.com/DesignLiquido/visualg/pull/4 para fazer os testes unitários passarem.

Aqui corrijo mais algumas coisas.:

- O `process.exit()` que existia antes na execução teve que ser completamente removido, porque o build do GitHub entende o `process.exit()` como uma saída inesperada. Não adianta fazer o mock (tentei dois métodos diferentes);
- A dependência com o `lodash` era só com o `clonedeep`, mas o TypeScript não entendia isso como o pacote completo, então agora o projeto do VisuAlg usa uma referência completa do `lodash`. O pacote fica maior, mas pelo menos resolve o problema.