### PR TITLE
Re-enable Égua try/catch regression coverage

### DIFF
--- a/bin/delegua-ts
+++ b/bin/delegua-ts
@@ -1,3 +1,11 @@
 #! /usr/bin/env ts-node
 
-require('../fontes/execucao');
+try {
+    require('../fontes/execucao');
+} catch (erro) {
+    if (erro && erro.code === 'MODULE_NOT_FOUND') {
+        require('../execucao');
+    } else {
+        throw erro;
+    }
+}

--- a/bin/delegua-ts
+++ b/bin/delegua-ts
@@ -4,7 +4,14 @@ try {
     require('../fontes/execucao');
 } catch (erro) {
     if (erro && erro.code === 'MODULE_NOT_FOUND') {
-        require('../execucao');
+        try {
+            require('../dist/execucao');
+        } catch (fallbackErro) {
+            if (fallbackErro && fallbackErro.code === 'MODULE_NOT_FOUND') {
+                throw erro;
+            }
+            throw fallbackErro;
+        }
     } else {
         throw erro;
     }

--- a/exemplos/dialetos/egua-classico/testes.egua
+++ b/exemplos/dialetos/egua-classico/testes.egua
@@ -16,7 +16,7 @@ função startTest(){
   escreva("|");
   escreva(tCasoEscolha());
   escreva("|");
-  //escreva(tTentePegue());
+  escreva(tTentePegue());
   escreva("|");
   escreva(tClasse());
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "empacotar": "yarn rimraf ./dist && tsc && yarn copyfiles -V ./bin/delegua ./bin/delegua.cmd ./dist && yarn copyfiles -V ./package.json ./dist/bin && yarn copyfiles -V ./README.md ./dist && yarn copyfiles -V ./LICENSE ./dist",
         "testes-unitarios": "yarn jest --coverage",
-        "testes:egua": "./bin/delegua-ts exemplos/dialetos/egua-classico/testes.egua",
+        "testes:egua": "./bin/delegua-ts --dialeto egua exemplos/dialetos/egua-classico/testes.egua",
         "testes:delegua:bhaskara": "./bin/delegua-ts exemplos/dialetos/egua-classico/bhaskara.egua",
         "testes:delegua:fibonacci": "./bin/delegua-ts exemplos/dialetos/egua-classico/fibonacci.egua",
         "testes:egua-classico": "./bin/delegua-ts --dialeto egua exemplos/dialetos/egua-classico/testes.egua",

--- a/testes/nucleo-execucao.test.ts
+++ b/testes/nucleo-execucao.test.ts
@@ -86,4 +86,28 @@ describe('Núcleo de execução', () => {
             });
         });
     });
+
+    it('Dialeto Égua executa bloco `pegue` quando comparação inválida ocorre', async () => {
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+        try {
+            const nucleoExecucao = new NucleoExecucao('0.1');
+            nucleoExecucao.configurarDialeto('egua');
+
+            await nucleoExecucao.executarCodigoComoArgumento(`
+tente {
+    1 > "1";
+    escreva("Tente - Pegue: ERRO!");
+} pegue {
+    escreva("Tente - Pegue: OK!");
+}`);
+
+            const saidas = consoleSpy.mock.calls.map(([mensagem]) =>
+                typeof mensagem === 'string' ? mensagem.trim() : ''
+            );
+            expect(saidas).toContain('Tente - Pegue: OK!');
+            expect(saidas).not.toContain('Tente - Pegue: ERRO!');
+        } finally {
+            consoleSpy.mockRestore();
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- re-enable the `tTentePegue` assertion in the Égua sample suite
- add a Jest regression test to ensure `tente/pegue` surfaces numeric comparison errors

## Testing
- yarn testes-unitarios

Resolves #22.